### PR TITLE
[Feature #161244331] Add a store sales record page

### DIFF
--- a/UI/html/store_sale_records.html
+++ b/UI/html/store_sale_records.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="eng">
+  <!--meta info about our document  -->
+  <head>
+    <!--  -->
+    <meta charset="utf-8">
+    <!-- title displayed for the website -->
+    <title>Attendant Sale Records</title>
+    <!-- link to our css-->
+    <!-- <link rel="stylesheet"  href="../css/style.css"> -->
+    <link rel="stylesheet"  href="../css/style_items.css">
+  </head>
+
+  <!-- VISIBLE PAGE CONTENT -->
+  <body>
+
+    <!-- <header> -->
+    <div class="header">
+      <div class ="biz-name">
+        <h4>KTC Stores</h4>
+        <h5>Sales</h5>
+      </div>
+    </div>
+      <ul>
+        <li><a href="new_attendant.html">New Account</a></li>
+        <li><a href="index.html">Logout</a></li>
+      </ul>
+
+      <div class="signIn">
+        <table>
+        <br><caption>Sales Made</caption><br>
+          <tr>
+           <th>Attendant</th>
+           <th>Item</th>
+           <th>Price</th>
+           <th>Quantity</th>
+          <th>Total</th>
+          <th>Attendant Details</th>
+          </tr>
+        </tr>
+        <tr>
+          <td>Buya</td>
+          <td>Timberland</td>
+          <td>$20</td>
+          <td>2</td>
+          <td>$40</td>
+          <th><a href="sale_records.html">Sale Details</th>
+        </tr>
+        <tr>
+          <td>Annie</td>
+          <td>Vans</td>
+          <td>$19</td>
+          <td>1</td>
+          <td>$19</td>
+          <th><a href="sale_records.html">Sale Details</th>
+        </tr>
+        <tr>
+          <td>Faay</td>
+          <td>Nike</td>
+          <td>$25</td>
+          <td>2</td>
+          <td>$50</td>
+          <th><a href="sale_records.html">Sale Details</th>
+        </tr>
+      </table>
+    </div>
+
+    <footer>
+      <p>KTC@2018</p>
+    </footer>
+
+  </body>
+
+</html>


### PR DESCRIPTION
**What does this PR do?**
Add a page where sales made can be viewed

**Description of task to be completed?**
Create a store sale records page
Style using css

**How should this be manually tested?**
Clone repository
https://github.com/OnyiegoAyub/CH1-Store-Manager
Cd to repository and checkout to the feature branch
git checkout ft-store-sale-records-page-161244331
open store_sale_records.html in a browser

What are the relevant pivotal tracker stories?
#16124433

**Screenshots(if appropriate)**
![store sale](https://user-images.githubusercontent.com/38955236/47002962-e37f2580-d136-11e8-87c0-6302ceb04385.PNG)
